### PR TITLE
info.xml: require CiviCRM 5.32 or later

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.0.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.32</ver>
   </compatibility>
   <comments></comments>
   <classloader>


### PR DESCRIPTION
This kind of syntax requires CiviCRM 5.32 or later:

```
      Civi::resources()->add(
        [
          'template' => 'Btcpaycontribution-thankyou-billing-block.tpl',
          'region' => 'form-top',
        ]
      );
```

The old syntax was:

```
      CRM_Core_Region::instance('form-top')->add([
        'template' => 'Btcpaycontribution-thankyou-billing-block.tpl',
      ]);
```

Considering that CiviCRM ESR is 5.33, and later versions of CiviCRM are unsupported, I think it's better to keep the code clean, and bump the minimum required version of CiviCRM.