### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,9 +18,9 @@
   <version>1.0.1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.32</ver>
+    <ver>5.65</ver>
   </compatibility>
-  <comments></comments>
+  <comments/>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>

--- a/templates/Btcpaycontribution-confirm-billing-block.tpl
+++ b/templates/Btcpaycontribution-confirm-billing-block.tpl
@@ -4,7 +4,7 @@
     {ts}Payment Information{/ts}
   </div>
   <div class="crm-section crm-btcpay-block">
-    <img src="{$btcpayServerUrl}/img/paybutton/pay.svg" alt="{ts escape='js'}Pay with BTCPay{/ts}" width="200px"/>
+    <img src="{$btcpayServerUrl}/img/paybutton/pay.svg" alt="{ts escape='htmlattribute'}Pay with BTCPay{/ts}" width="200px"/>
     <p>
       {ts}When you continue, your BTCPay invoice and the Crypto Address (currently supports Bitcoin and Litecoin) will be displayed on screen{/ts}
     </p>

--- a/templates/Btcpaycontribution-thankyou-billing-block.tpl
+++ b/templates/Btcpaycontribution-thankyou-billing-block.tpl
@@ -33,7 +33,7 @@
   <div class="crm-section crm-btcpay-block">
     <div class="crm-btcpay" id="btcpay-trxnid" style="display: none">{$btcpayTrxnId}</div>
     <a id="btcpay-payment-link" href="javascript:void(0)" onclick="btcpay.showInvoice('{$btcpayTrxnId}')">
-      <img src="{$btcpayServerUrl}/img/paybutton/pay.svg" alt="{ts escape='js'}Pay with BTCPay{/ts}" style="padding: 30px"/>
+      <img src="{$btcpayServerUrl}/img/paybutton/pay.svg" alt="{ts escape='htmlattribute'}Pay with BTCPay{/ts}" style="padding: 30px"/>
     </a>
   </div>
 </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.