### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Btcpay/Client.php
+++ b/CRM/Btcpay/Client.php
@@ -39,7 +39,7 @@ class CRM_Btcpay_Client {
    *
    * @return \BTCPayServer\Client\Client
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function getClient() {
     $storageEngine = new \BTCPayServer\Storage\EncryptedFilesystemStorage(CRM_Btcpay_Keys::getKeyPassword($this->_paymentProcessor['id'])); // Password may need to be updated if you changed it

--- a/CRM/Btcpay/Keys.php
+++ b/CRM/Btcpay/Keys.php
@@ -46,7 +46,7 @@ class CRM_Btcpay_Keys {
    * @param $processorId
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function getKeyPassword($processorId) {
     $paymentProcessor = civicrm_api3('PaymentProcessor', 'getsingle', [

--- a/CRM/Core/Payment/Btcpay.php
+++ b/CRM/Core/Payment/Btcpay.php
@@ -151,7 +151,7 @@ class CRM_Core_Payment_Btcpay extends CRM_Core_Payment {
    *   Result array
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function doPayment(&$params, $component = 'contribute') {
     Civi::log()->debug(print_r($component, TRUE));
@@ -238,7 +238,7 @@ class CRM_Core_Payment_Btcpay extends CRM_Core_Payment {
    * Process incoming payment notification (IPN).
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function handlePaymentNotification() {
     $dataRaw = file_get_contents("php://input");

--- a/CRM/Core/Payment/BtcpayIPN.php
+++ b/CRM/Core/Payment/BtcpayIPN.php
@@ -82,7 +82,7 @@ class CRM_Core_Payment_BtcpayIPN extends CRM_Core_Payment_BaseIPN
    * Main handler for btcpay IPN callback
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function main()
   {
@@ -180,7 +180,7 @@ class CRM_Core_Payment_BtcpayIPN extends CRM_Core_Payment_BaseIPN
    * set by Civi's handle IPN hook
    *
    * @return void
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    *
    */
   private function getPaymentProcessorForUnitTest($paymentProcessorId)

--- a/CRM/Core/Payment/BtcpayIPNTrait.php
+++ b/CRM/Core/Payment/BtcpayIPNTrait.php
@@ -49,7 +49,7 @@ trait CRM_Core_Payment_BtcpayIPNTrait {
    * @param array $params [ 'id' -> contribution_id, 'payment_processor_id' -> payment_processor_id]
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function canceltransaction($params) {
     return $this->incompletetransaction($params, 'cancel');
@@ -61,7 +61,7 @@ trait CRM_Core_Payment_BtcpayIPNTrait {
    * @param array $params [ 'id' -> contribution_id, 'payment_processor_id' -> payment_processor_id]
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function failtransaction($params) {
     return $this->incompletetransaction($params, 'fail');
@@ -74,7 +74,7 @@ trait CRM_Core_Payment_BtcpayIPNTrait {
    * @param string $mode
    *
    * @return bool
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function incompletetransaction($params, $mode) {
     $requiredParams = ['id', 'payment_processor_id'];
@@ -90,11 +90,11 @@ trait CRM_Core_Payment_BtcpayIPNTrait {
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $params['id'];
     if (!$contribution->find(TRUE)) {
-      throw new CiviCRM_API3_Exception('A valid contribution ID is required', 'invalid_data');
+      throw new CRM_Core_Exception('A valid contribution ID is required', 'invalid_data');
     }
 
     if (!$contribution->loadRelatedObjects($input, $ids, TRUE)) {
-      throw new CiviCRM_API3_Exception('failed to load related objects');
+      throw new CRM_Core_Exception('failed to load related objects');
     }
 
     $input['trxn_id'] = !empty($params['trxn_id']) ? $params['trxn_id'] : $contribution->trxn_id;
@@ -114,7 +114,7 @@ trait CRM_Core_Payment_BtcpayIPNTrait {
         return $this->failed($objects, $transaction);
 
       default:
-        throw new CiviCRM_API3_Exception('Unknown incomplete transaction type: ' . $mode);
+        throw new CRM_Core_Exception('Unknown incomplete transaction type: ' . $mode);
     }
 
   }

--- a/CRM/Core/Payment/BtcpayTrait.php
+++ b/CRM/Core/Payment/BtcpayTrait.php
@@ -43,7 +43,7 @@ trait CRM_Core_Payment_BtcpayTrait {
           'return' => ['email'],
         ));
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         return NULL;
       }
     }
@@ -131,7 +131,7 @@ trait CRM_Core_Payment_BtcpayTrait {
    * @param array $params ['name' => payment instrument name]
    *
    * @return int|null
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function createPaymentInstrument($params) {
     $mandatoryParams = ['name'];

--- a/api/v3/Btcpay.php
+++ b/api/v3/Btcpay.php
@@ -61,7 +61,7 @@ function _civicrm_api3_btcpay_pair_spec(&$spec) {
  * @param $params
  *
  * @return array
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_btcpay_checkinstall($params) {
   $result = CRM_Core_Payment_Btcpay::createPaymentInstrument(['name' => 'Bitcoin']);

--- a/tests/phpunit/CRM/Core/Payment/BtcpayTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BtcpayTest.php
@@ -54,7 +54,7 @@ class CRM_Core_Payment_BtcpayTest extends \PHPUnit\Framework\TestCase implements
    * Btcpay payment processors.
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function testBtcpayGeneratesBtcpayInvoiceOnContributionPage() {


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.