### PR TITLE
Remove usage of deprecated core functions

### DIFF
--- a/btcpay.civix.php
+++ b/btcpay.civix.php
@@ -7,11 +7,8 @@
  * extension.
  */
 class CRM_Btcpay_ExtensionUtil {
-
   const SHORT_NAME = 'btcpay';
-
   const LONG_NAME = 'btcpay';
-
   const CLASS_PREFIX = 'CRM_Btcpay';
 
   /**
@@ -23,12 +20,11 @@ class CRM_Btcpay_ExtensionUtil {
    * @param string $text
    *   Canonical message text (generally en_US).
    * @param array $params
-   *
    * @return string
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -41,15 +37,13 @@ class CRM_Btcpay_ExtensionUtil {
    * @param string|NULL $file
    *   Ex: NULL.
    *   Ex: 'css/foo.css'.
-   *
    * @return string
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
-      return rtrim(CRM_Core_Resources::singleton()
-        ->getUrl(self::LONG_NAME), '/');
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
     return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
   }
@@ -60,7 +54,6 @@ class CRM_Btcpay_ExtensionUtil {
    * @param string|NULL $file
    *   Ex: NULL.
    *   Ex: 'css/foo.css'.
-   *
    * @return string
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
@@ -75,7 +68,6 @@ class CRM_Btcpay_ExtensionUtil {
    *
    * @param string $suffix
    *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
-   *
    * @return string
    *   Ex: 'CRM_Foo_Page_HelloWorld'.
    */
@@ -92,40 +84,17 @@ use CRM_Btcpay_ExtensionUtil as E;
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _btcpay_civix_civicrm_config(&$config = NULL) {
+function _btcpay_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
-
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function _btcpay_civix_civicrm_xmlMenu(&$files) {
-  foreach (_btcpay_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -135,35 +104,7 @@ function _btcpay_civix_civicrm_xmlMenu(&$files) {
  */
 function _btcpay_civix_civicrm_install() {
   _btcpay_civix_civicrm_config();
-  if ($upgrader = _btcpay_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _btcpay_civix_civicrm_postInstall() {
-  _btcpay_civix_civicrm_config();
-  if ($upgrader = _btcpay_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _btcpay_civix_civicrm_uninstall() {
-  _btcpay_civix_civicrm_config();
-  if ($upgrader = _btcpay_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -171,223 +112,16 @@ function _btcpay_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _btcpay_civix_civicrm_enable() {
+function _btcpay_civix_civicrm_enable(): void {
   _btcpay_civix_civicrm_config();
-  if ($upgrader = _btcpay_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _btcpay_civix_civicrm_disable() {
-  _btcpay_civix_civicrm_config();
-  if ($upgrader = _btcpay_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or
- *   'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of
- *   pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are
- *   pending) for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _btcpay_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _btcpay_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_Btcpay_Upgrader
- */
-function _btcpay_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Btcpay/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_Btcpay_Upgrader_Base::instance();
-  }
-}
-
-/**
- * Search directory tree for files which match a glob pattern.
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
- *
- * @param string $dir base dir
- * @param string $pattern , glob pattern, eg "*.txt"
- *
- * @return array
- */
-function _btcpay_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_btcpay_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
-}
-
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function _btcpay_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _btcpay_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function _btcpay_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_btcpay_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function _btcpay_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _btcpay_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_themes().
- *
- * Find any and return any files matching "*.theme.php"
- */
-function _btcpay_civix_civicrm_themes(&$themes) {
-  $files = _btcpay_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
-    }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- *
- * @param string $pattern
- *
- * @return array
- */
-function _btcpay_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path to parent of this item, e.g.
- *   'my_extension/submenu'
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
@@ -399,7 +133,7 @@ function _btcpay_civix_insert_navigation_menu(&$menu, $path, $item) {
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label' => CRM_Utils_Array::value('name', $item),
+        'label' => $item['name'] ?? NULL,
         'active' => 1,
       ], $item),
     ];
@@ -437,7 +171,7 @@ function _btcpay_civix_navigationMenu(&$nodes) {
  */
 function _btcpay_civix_fixNavigationMenu(&$nodes) {
   $maxNavID = 1;
-  array_walk_recursive($nodes, function ($item, $key) use (&$maxNavID) {
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
     if ($key === 'navID') {
       $maxNavID = max($maxNavID, $item);
     }
@@ -463,27 +197,4 @@ function _btcpay_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
       _btcpay_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _btcpay_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _btcpay_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/btcpay.php
+++ b/btcpay.php
@@ -36,15 +36,6 @@ function btcpay_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function btcpay_civicrm_xmlMenu(&$files) {
-  _btcpay_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
@@ -60,16 +51,6 @@ function btcpay_civicrm_install() {
  */
 function btcpay_civicrm_postInstall() {
   CRM_Core_Payment_Btcpay::createPaymentInstrument(['name' => 'Bitcoin']);
-  _btcpay_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function btcpay_civicrm_uninstall() {
-  _btcpay_civix_civicrm_uninstall();
 }
 
 /**
@@ -79,90 +60,6 @@ function btcpay_civicrm_uninstall() {
  */
 function btcpay_civicrm_enable() {
   _btcpay_civix_civicrm_enable();
-}
-
-/**
- * Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- */
-function btcpay_civicrm_disable() {
-  _btcpay_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function btcpay_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _btcpay_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function btcpay_civicrm_managed(&$entities) {
-  _btcpay_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function btcpay_civicrm_caseTypes(&$caseTypes) {
-  _btcpay_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function btcpay_civicrm_angularModules(&$angularModules) {
-  _btcpay_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function btcpay_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _btcpay_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * Declare entity types provided by this module.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function btcpay_civicrm_entityTypes(&$entityTypes) {
-  _btcpay_civix_civicrm_entityTypes($entityTypes);
-}
-
-/**
- * Implements hook_civicrm_thems().
- */
-function btcpay_civicrm_themes(&$themes) {
-  _btcpay_civix_civicrm_themes($themes);
 }
 
 /**

--- a/info.xml
+++ b/info.xml
@@ -23,8 +23,15 @@
   <comments/>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
+    <psr0 prefix="CRM_" path="."/>
   </classloader>
   <civix>
     <namespace>CRM/Btcpay</namespace>
+    <format>25.10.2</format>
   </civix>
+  <mixins>
+    <mixin>mgd-php@2.0.0</mixin>
+    <mixin>smarty-v2@1.0.3</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/mixin/mgd-php@2.0.0.mixin.php
+++ b/mixin/mgd-php@2.0.0.mixin.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Auto-register "**.mgd.php" files.
+ *
+ * The older (mgd-php@1) and newer (mgd-php@2) are similar in that both load `*.mgd.php` files.
+ * However, they differ in how the search:
+ *
+ * - v1.x does a broad search over the entire extension source-tree.
+ * - v2.x does a narrower search in folders which commonly have mgds.
+ *   Within 2.x, future increments may add other paths (after vetting `universe` for impacts).
+ *
+ * @mixinName mgd-php
+ * @mixinVersion 2.0.0
+ * @since 6.9
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::managed()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_managed', function ($event) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    // Optimization: if managed entities were requested for specific module(s),
+    // check name and return early if not applicable.
+    if ($event->modules && !in_array($mixInfo->longName, $event->modules, TRUE)) {
+      return;
+    }
+
+    $path = $mixInfo->getPath();
+    $mgdFiles = array_merge(
+      (array) glob("$path/*.mgd.php"),
+      CRM_Utils_File::findFiles("$path/managed", '*.mgd.php'),
+      CRM_Utils_File::findFiles("$path/api", '*.mgd.php'),
+      CRM_Utils_File::findFiles("$path/CRM", '*.mgd.php'),
+      CRM_Utils_File::findFiles("$path/Civi", '*.mgd.php'),
+    );
+
+    sort($mgdFiles);
+    foreach ($mgdFiles as $file) {
+      $es = include $file;
+      foreach ($es as $e) {
+        if (empty($e['module'])) {
+          $e['module'] = $mixInfo->longName;
+        }
+        if (empty($e['params']['version'])) {
+          $e['params']['version'] = '3';
+        }
+        if (empty($e['source'])) {
+          $e['source'] = $file;
+        }
+        $event->entities[] = $e;
+      }
+    }
+  });
+
+};

--- a/mixin/smarty-v2@1.0.3.mixin.php
+++ b/mixin/smarty-v2@1.0.3.mixin.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Auto-register "templates/" folder.
+ *
+ * @mixinName smarty-v2
+ * @mixinVersion 1.0.3
+ * @since 5.59
+ *
+ * @deprecated - it turns out that the mixin is not version specific so the 'smarty'
+ * mixin is preferred over smarty-v2 (they are the same but not having the version
+ * in the name is less misleading.)
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+  $dir = $mixInfo->getPath('templates');
+  if (!file_exists($dir)) {
+    return;
+  }
+
+  $register = function($newDirs) {
+    $smarty = CRM_Core_Smarty::singleton();
+    $v2 = isset($smarty->_version) && version_compare($smarty->_version, 3, '<');
+    $templateDirs = (array) ($v2 ? $smarty->template_dir : $smarty->getTemplateDir());
+    $templateDirs = array_merge($newDirs, $templateDirs);
+    $templateDirs = array_unique(array_map(function($v) {
+      $v = str_replace(DIRECTORY_SEPARATOR, '/', $v);
+      $v = rtrim($v, '/') . '/';
+      return $v;
+    }, $templateDirs));
+    if ($v2) {
+      $smarty->template_dir = $templateDirs;
+    }
+    else {
+      $smarty->setTemplateDir($templateDirs);
+    }
+  };
+
+  // Let's figure out what environment we're in -- so that we know the best way to call $register().
+
+  if (!empty($GLOBALS['_CIVIX_MIXIN_POLYFILL'])) {
+    // Polyfill Loader (v<=5.45): We're already in the middle of firing `hook_config`.
+    if ($mixInfo->isActive()) {
+      $register([$dir]);
+    }
+    return;
+  }
+
+  if (CRM_Extension_System::singleton()->getManager()->extensionIsBeingInstalledOrEnabled($mixInfo->longName)) {
+    // New Install, Standard Loader: The extension has just been enabled, and we're now setting it up.
+    // System has already booted. New templates may be needed for upcoming installation steps.
+    $register([$dir]);
+    return;
+  }
+
+  // Typical Pageview, Standard Loader: Defer the actual registration for a moment -- to ensure that Smarty is online.
+  // We need to bundle-up all dirs -- Smarty 3/4/5 is inefficient with processing repeated calls to `getTemplateDir()`+`setTemplateDir()`
+  if (!isset(Civi::$statics[__FILE__]['event'])) {
+    Civi::$statics[__FILE__]['event'] = 'civi.smarty-v2.addPaths.' . md5(__FILE__);
+    Civi::dispatcher()->addListener('hook_civicrm_config', function() use ($register) {
+      $dirs = [];
+      $event = \Civi\Core\Event\GenericHookEvent::create(['dirs' => &$dirs]);
+      Civi::dispatcher()->dispatch(Civi::$statics[__FILE__]['event'], $event);
+      $register($dirs);
+    });
+  }
+
+  Civi::dispatcher()->addListener(Civi::$statics[__FILE__]['event'], function($event) use ($mixInfo, $dir) {
+    if ($mixInfo->isActive()) {
+      array_unshift($event->dirs, $dir);
+    }
+  });
+
+};


### PR DESCRIPTION
These functions are being removed from core. Note that simply updating the status is inline with core processors now

- also includes a civix update - this adds a few mixins because the  min-supported civi version is still quite low
- 
https://github.com/civicrm/civicrm-core/pull/34025